### PR TITLE
Make workspace symbol search case-insensitive

### DIFF
--- a/src/dart_diagnostic_provider.ts
+++ b/src/dart_diagnostic_provider.ts
@@ -2,6 +2,7 @@
 
 import { DiagnosticCollection, Diagnostic, DiagnosticSeverity, Uri, Range, Position } from "vscode";
 import { Analyzer } from "./analyzer";
+import { toRange } from "./utils";
 import * as as from "./analysis_server_types";
 
 export class DartDiagnosticProvider {
@@ -22,13 +23,10 @@ export class DartDiagnosticProvider {
 	}
 
 	private createDiagnostic(error: as.AnalysisError): Diagnostic {
-		let startPos = new Position(error.location.startLine - 1, error.location.startColumn - 1); // TODO: Abstract this out; esp as G are 1-based, MS 0-based!
-		let endPos = startPos.translate(0, error.location.length);
-
 		return {
 			code: error.code,
 			message: error.message,
-			range: new Range(startPos, endPos),
+			range: toRange(error.location),
 			severity: this.getSeverity(error.severity),
 			source: error.type
 		};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,8 @@
 
 import * as path from "path";
 import * as fs from "fs";
-import { workspace } from "vscode";
+import * as as from "./analysis_server_types";
+import { workspace, Position, Range } from "vscode";
 
 export const dartVMPath = "bin/dart";
 export const analyzerPath = "bin/snapshots/analysis_server.dart.snapshot";
@@ -50,4 +51,13 @@ function hasDartExecutable(pathToTest: string): boolean {
     catch (e) { }
 
     return false; // Didn't find it, so must be an invalid path.
+}
+
+export function toPosition(location: as.Location): Position {
+    return new Position(location.startLine - 1, location.startColumn - 1);
+}
+
+export function toRange(location: as.Location): Range {
+    let startPos = toPosition(location);
+    return new Range(startPos, startPos.translate(0, location.length));
 }


### PR DESCRIPTION
- allow case insensitive search in the workspace symbol dialog
- add some common logic to convert from analysis server locations to vscode ones (fix https://github.com/DanTup/Dart-Code/issues/10)

<img width="258" alt="screen shot 2016-08-06 at 12 00 20 am" src="https://cloud.githubusercontent.com/assets/1269969/17455323/ccf4d2ce-5b68-11e6-9203-43a3fd1f425c.png">
