### PR TITLE
Show analysis status in status bar (+ other tweaks)

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
 				},
 				"dart.showTodos": {
 					"type": "boolean",
-					"default": false,
+					"default": true,
 					"description": "Show TODOs in the Problems view."
 				}
 			}

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -117,9 +117,7 @@ export class Analyzer extends AnalyzerGen {
 	stop() {
 		console.log(`Stopping Dart analysis server...`);
 
-		// TODO: Figure out if it's ok to be slow when deactivating an extension.
-
-		this.serverShutdown().then(() => this.analyzerProcess.kill());
+		this.analyzerProcess.kill();
 	}
 }
 

--- a/src/dart_diagnostic_provider.ts
+++ b/src/dart_diagnostic_provider.ts
@@ -17,7 +17,7 @@ export class DartDiagnosticProvider {
 
 	private handleErrors(notification: as.AnalysisErrorsNotification) {
 		let errors = notification.errors;
-		if (!getConfig('showTodos'))
+		if (!getConfig<boolean>('showTodos'))
 			errors = errors.filter((error) => error.type != 'TODO');
 		this.diagnostics.set(
 			Uri.file(notification.file), 

--- a/src/dart_hover_provider.ts
+++ b/src/dart_hover_provider.ts
@@ -16,14 +16,20 @@ export class DartHoverProvider implements HoverProvider {
 				file: document.fileName,
 				offset: document.offsetAt(position)
 			}).then(resp => {
-				if (resp.hovers.length == 0)
+				if (resp.hovers.length == 0) {
 					resolve(null);
-				else {
-					let range = new Range(
-						document.positionAt(resp.hovers[0].offset),
-						document.positionAt(resp.hovers[0].offset + resp.hovers[0].length)
-					);
-					resolve(new Hover(resp.hovers.map(this.getHoverData), range));
+				} else {
+					let hover = resp.hovers[0];
+					let markdown = this.getHoverData(hover);
+					if (markdown) {
+						let range = new Range(
+							document.positionAt(hover.offset),
+							document.positionAt(hover.offset + hover.length)
+						);
+						resolve(new Hover(markdown, range));
+					} else {
+						resolve(null);
+					}
 				}
 			});
 		});

--- a/src/file_change_handler.ts
+++ b/src/file_change_handler.ts
@@ -11,6 +11,9 @@ export class FileChangeHandler {
 	}
 
 	onDidOpenTextDocument(document: vscode.TextDocument) {
+		if (!this.isDartLike(document))
+		  return;
+
 		let files: { [key: string]: as.AddContentOverlay } = {};
 
 		files[document.fileName] = {
@@ -22,6 +25,9 @@ export class FileChangeHandler {
 	}
 
 	onDidChangeTextDocument(e: vscode.TextDocumentChangeEvent) {
+		if (!this.isDartLike(e.document))
+		  return;
+
 		// TODO: Fix this...
 		// HACK: e.document.offsetAt appears to return the wrong offset when there are
 		// multiple edits (since it uses the current document state which can include
@@ -54,6 +60,9 @@ export class FileChangeHandler {
 	}
 
 	onDidCloseTextDocument(document: vscode.TextDocument) {
+		if (!this.isDartLike(document))
+		  return;
+
 		let files: { [key: string]: as.RemoveContentOverlay } = {};
 
 		files[document.fileName] = {
@@ -70,5 +79,13 @@ export class FileChangeHandler {
 			replacement: change.text,
 			id: "" // TODO: Fix this, should be optional!
 		}
+	}
+
+	private isDartLike(document: vscode.TextDocument): boolean {
+		if (document.isUntitled || !document.fileName)
+			return false;
+		
+		let fileName = document.fileName;
+		return fileName.endsWith('.dart') || fileName == '.analysis_options';
 	}
 }


### PR DESCRIPTION
- show analysis status (`Analyzing...`) in the status line when the analysis server is busy
- default showing todos to true (fix #39)
- reanalyze sources when the setting for showing todos changes
- don't call `serverShutdown` - if I understand correctly it's basically a no-op
- fix an issue w/ tooltips where some elements (string constants) would show a small, no content tooltip
- only send overlays for files that the analysis server needs to be aware of

@DanTup, it's a grab bag of work. Probably it for this weekend! I'm excited that Dart's getting a plugin for vscode :)
