### PR TITLE
add command pub.get, pub.upgrade

### DIFF
--- a/media/pull-inverse.svg
+++ b/media/pull-inverse.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><rect x="3" y="2" width="10" height="5" fill="#C5C5C5"/><polygon points="9,8 7,8 7,11 5,9 5,11 8,14 11,11 11,9 9,11" fill="#75BEFF"/></svg>

--- a/media/pull.svg
+++ b/media/pull.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><rect x="3" y="2" width="10" height="5" fill="#424242"/><polygon points="9,8 7,8 7,11 5,9 5,11 8,14 11,11 11,9 9,11" fill="#00539C"/></svg>

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
 	"icon": "media/icon.png",
 	"activationEvents": [
 		"onLanguage:dart",
-		"workspaceContains:pubspec.yaml"
+		"workspaceContains:pubspec.yaml",
+		"onCommand:pub.get",
+		"onCommand:pub.upgrade"
 	],
 	"main": "./out/src/extension",
 	"contributes": {
@@ -53,6 +55,56 @@
 				"path": "./syntaxes/dart.json"
 			}
 		],
+		"commands": [
+			{
+				"command": "pub.get",
+				"title": "Pub Get",
+				"category": "Dart",
+				"icon": {
+					"light": "./media/pull.svg",
+					"dark": "./media/pull-inverse.svg"
+				}
+			},
+			{
+				"command": "pub.upgrade",
+				"title": "Pub Upgrade",
+				"category": "Dart",
+				"icon": {
+					"light": "./media/pull.svg",
+					"dark": "./media/pull-inverse.svg"
+				}
+			}
+		],
+		"menus": {
+			"editor/title": [
+				{
+					"when": "resourceLangId == yaml",
+					"command": "pub.get",
+					"alt": "pub.upgrade",
+					"group": "navigation"
+				}
+			],
+			"editor/context": [
+				{
+					"when": "resourceLangId == yaml",
+					"command": "pub.get"
+				},
+				{
+					"when": "resourceLangId == yaml",
+					"command": "pub.upgrade"
+				}
+			],
+			"explorer/context": [
+				{
+					"when": "resourceLangId == yaml",
+					"command": "pub.get"
+				},
+				{
+					"when": "resourceLangId == yaml",
+					"command": "pub.upgrade"
+				}
+			]
+		},
 		"configuration": {
 			"type": "object",
 			"title": "Dart Configuration",

--- a/src/channels.ts
+++ b/src/channels.ts
@@ -1,0 +1,21 @@
+'use strict';
+
+import * as child_process from 'child_process';
+import * as vs from 'vscode';
+
+let channels: { [key: string]: vs.OutputChannel } = {};
+
+export function getCreateChannel(name: string): vs.OutputChannel {
+    if (channels[name] == null)
+        channels[name] = vs.window.createOutputChannel(name);
+    else
+        channels[name].clear();
+
+    return channels[name];
+}
+
+export function runProcessInChannel(process: child_process.ChildProcess, channel: vs.OutputChannel) {
+    process.stdout.on('data', (data) => channel.append(data));
+    process.stderr.on('data', (data) => channel.append(data));
+    process.on('close', (code) => channel.appendLine(`exit code ${code}`));
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,6 +18,7 @@ import { DartDocumentSymbolProvider } from "./dart_document_symbol_provider";
 import { DartWorkspaceSymbolProvider } from "./dart_workspace_symbol_provider";
 import { FileChangeHandler } from "./file_change_handler";
 import { OpenFileTracker } from "./open_file_tracker";
+import { PubManager } from "./pub";
 import { ServerStatusNotification } from "./analysis_server_types";
 
 const DART_MODE: vscode.DocumentFilter = { language: "dart", scheme: "file" };
@@ -99,6 +100,9 @@ export function activate(context: vscode.ExtensionContext) {
 
 	// Handle config changes so we can reanalyze if necessary.
 	context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(handleConfigurationChange));
+
+	let pubManager = new PubManager(dartSdkRoot);
+    pubManager.registerCommands(context);
 }
 
 function handleConfigurationChange() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -102,7 +102,7 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(handleConfigurationChange));
 
 	let pubManager = new PubManager(dartSdkRoot);
-    pubManager.registerCommands(context);
+	pubManager.registerCommands(context);
 }
 
 function handleConfigurationChange() {

--- a/src/project.ts
+++ b/src/project.ts
@@ -1,0 +1,32 @@
+'use strict';
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vs from 'vscode';
+
+export function locateBestProjectRoot(): string {
+	let root = vs.workspace.rootPath;
+	if (!root)
+		return null;
+
+	let editor = vs.window.activeTextEditor;
+	if (!editor)
+		return root;
+
+	let file = editor.document.fileName;
+	if (editor.document.isUntitled || !file)
+		return root;
+
+	// Make sure the current file is under the root.
+	if (!file.startsWith(root))
+		return root;
+
+	let dir = path.dirname(file);
+	while (dir != root && dir.length > 1) {
+		if (fs.existsSync(path.join(dir, 'pubspec.yaml')))
+			return dir;
+		dir = path.dirname(dir);
+	}
+
+	return root;
+}

--- a/src/pub.ts
+++ b/src/pub.ts
@@ -1,0 +1,44 @@
+'use strict';
+
+import * as channels from "./channels";
+import * as child_process from "child_process";
+import * as os from "os";
+import * as path from "path";
+import * as project from "./project";
+import * as vs from "vscode";
+
+export class PubManager {
+	private sdk: string;
+
+	constructor(sdk: string) {
+		this.sdk = sdk;
+	}
+
+	registerCommands(context: vs.ExtensionContext) {
+		context.subscriptions.push(vs.commands.registerCommand("pub.get", selection => {
+			this.runPub("get", selection);
+		}));
+		context.subscriptions.push(vs.commands.registerCommand("pub.upgrade", selection => {
+			this.runPub("upgrade", selection);
+		}));
+	}
+
+	private runPub(command: String, selection?) {
+		let root = vs.workspace.rootPath;
+		let projectPath = selection
+			? path.dirname(selection.path)
+			: project.locateBestProjectRoot();
+		let shortPath = path.join(path.basename(root), path.relative(root, projectPath));
+		let channel = channels.getCreateChannel("Pub");
+		channel.show(true);
+
+		// TODO: Add a wrapper around the Dart SDK? It could do things like
+		// return the paths for tools in the bin/ dir. 
+		let pubPath = os.platform() == "win32"
+			? path.join(this.sdk, "bin", "pub.bat")
+			: path.join(this.sdk, "bin", "pub");
+		channel.appendLine(`[${shortPath}] pub ${command}`);
+		let process = child_process.exec(`${pubPath} ${command}`, { "cwd": projectPath });
+		channels.runProcessInChannel(process, channel);
+	}
+}


### PR DESCRIPTION
- add command pub.get, pub.upgrade
- have their output go to a dedicated output view at the bottom (this may not be the best long term UX)
- expose the commands on the navigator context menu, editor context menu, and in the editor toolbar when the pubspec.yaml file is open

<img width="242" alt="screen shot 2016-08-10 at 5 17 04 am" src="https://cloud.githubusercontent.com/assets/1269969/17553495/eceacb56-5eba-11e6-9073-f84b77b5f610.png">

<img width="288" alt="screen shot 2016-08-10 at 5 17 14 am" src="https://cloud.githubusercontent.com/assets/1269969/17553496/ecedef48-5eba-11e6-93e3-31c9a105814f.png">

<img width="506" alt="screen shot 2016-08-10 at 5 17 21 am" src="https://cloud.githubusercontent.com/assets/1269969/17553494/ecea9834-5eba-11e6-8318-0b17a0ddbce2.png">

These commands are active when editing a yaml file; I couldn't find a way to scope it to just a pubspec.yaml file.