### PR TITLE
Remove diagnostics for deleted files.

### DIFF
--- a/src/dart_diagnostic_provider.ts
+++ b/src/dart_diagnostic_provider.ts
@@ -14,6 +14,9 @@ export class DartDiagnosticProvider {
 		this.diagnostics = diagnostics;
 
 		this.analyzer.registerForAnalysisErrors(es => this.handleErrors(es));
+
+		// Fired when files are deleted
+		this.analyzer.registerForAnalysisFlushResults(es => this.flushResults(es));
 	}
 
 	private handleErrors(notification: as.AnalysisErrorsNotification) {
@@ -46,6 +49,14 @@ export class DartDiagnosticProvider {
 				return DiagnosticSeverity.Information;
 			default:
 				throw new Error("Unknown severity type: " + severity); 
+		}
+	}
+
+	private flushResults(notification: as.AnalysisFlushResultsNotification) {		
+		if (notification.files) {
+			notification.files.forEach(file => {
+				this.diagnostics.delete(Uri.file(file));
+			});
 		}
 	}
 }

--- a/src/dart_diagnostic_provider.ts
+++ b/src/dart_diagnostic_provider.ts
@@ -52,11 +52,8 @@ export class DartDiagnosticProvider {
 		}
 	}
 
-	private flushResults(notification: as.AnalysisFlushResultsNotification) {		
-		if (notification.files) {
-			notification.files.forEach(file => {
-				this.diagnostics.delete(Uri.file(file));
-			});
-		}
+	private flushResults(notification: as.AnalysisFlushResultsNotification) {
+		let entries = notification.files.map<[Uri, Diagnostic[]]>(file => [Uri.file(file), undefined]);
+		this.diagnostics.set(entries);
 	}
 }


### PR DESCRIPTION
Subscribe to analysis.flushResults and remove all diagnostics for deleted files.

For issue #33